### PR TITLE
Remove unused argument to GetAntennaLoadPowerSpectrumNorm

### DIFF
--- a/FieldClasses/CMakeLists.txt
+++ b/FieldClasses/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_library(FieldClasses FieldClasses.cxx)
-target_link_libraries(FieldClasses PUBLIC BasicFunctions SignalProcessing ${ROOT_LIBRARIES} ${ROOTFFTW_LIB})
+target_link_libraries(FieldClasses PUBLIC BasicFunctions ${ROOT_LIBRARIES} ${ROOTFFTW_LIB})

--- a/FieldClasses/FieldClasses.cxx
+++ b/FieldClasses/FieldClasses.cxx
@@ -600,8 +600,7 @@ TGraph* rad::FieldPoint::GetTotalEFieldPowerSpectrumNorm(const bool kUseRetarded
 
 TGraph* rad::FieldPoint::GetAntennaLoadPowerSpectrumNorm(const double resistance,
 							 const bool kUseRetardedTime,
-							 int firstPoint, int lastPoint,
-							 std::vector<GaussianNoise*> noiseTerms) {
+							 int firstPoint, int lastPoint) {
   TGraph* grVoltage = GetAntennaLoadVoltageTimeDomain(kUseRetardedTime, firstPoint, lastPoint);
   TGraph* grPower = MakePowerSpectrumNorm(grVoltage);
 

--- a/FieldClasses/FieldClasses.h
+++ b/FieldClasses/FieldClasses.h
@@ -13,7 +13,6 @@
 
 #include "BasicFunctions/BasicFunctions.h"
 #include "BasicFunctions/EMFunctions.h"
-#include "SignalProcessing/NoiseFunc.h"
 #include "Antennas/IAntenna.h"
 
 namespace rad
@@ -176,8 +175,7 @@ namespace rad
     /// \param kUseRetardedTime Boolean to use retarded time
     TGraph* GetAntennaLoadPowerSpectrumNorm(const double resistance,
 					    const bool kUseRetardedTime=false,
-					    int firstPoint=-1, int lastPoint=-1,
-					    std::vector<GaussianNoise*> noiseTerms={});
+					    int firstPoint=-1, int lastPoint=-1);
     
     // Functions for various useful things such as the final time in a file
     double GetFinalTime();


### PR DESCRIPTION
Removes superfluous (and circular?) FieldClasses dependency on SignalProcessing.

@sebj101 This looks ok, but it's possible you had plans for this argument at some point?